### PR TITLE
feat(netbird): add PAT seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **PAT seeding**: Optional Personal Access Token seeding via `pat.*` values.
-  When `pat.enabled: true`, a post-install/post-upgrade Helm hook Job seeds
-  a service user account and PAT into the database using Initium's `seed` command.
-  The Job waits for the server to create its schema (GORM AutoMigrate), then
-  idempotently inserts account, user, and PAT records.
-- PAT seed Job uses `wait-for` init container to wait for server TCP readiness
-  before seeding.
+  When `pat.enabled: true`, a service user account and PAT are seeded into
+  the database using Initium's `seed` command. The seed waits for the server
+  to create its schema (GORM AutoMigrate), then idempotently inserts account,
+  user, and PAT records.
+- **SQLite**: PAT seed runs as a Kubernetes native sidecar (init container with
+  `restartPolicy: Always`, K8s 1.28+) in the server Deployment. The sidecar
+  uses Initium's `--sidecar` flag to stay alive after seeding, maintaining
+  full pod readiness (`2/2 Running`). This avoids ReadWriteOnce PVC
+  multi-attach issues that prevent a separate Job from mounting the PVC.
+- **PostgreSQL/MySQL**: PAT seed runs as a post-install/post-upgrade Helm hook
+  Job with a `wait-for` init container for server TCP readiness.
 - PAT seed spec uses `wait_for` to wait for `accounts`, `users`, and
   `personal_access_tokens` tables before inserting data.
 - PAT seed data uses `unique_key` for idempotent inserts (safe on re-installs).
-- PAT seed ConfigMap and Job are Helm hooks (post-install, post-upgrade) with
-  `before-hook-creation` delete policy.
+- PAT seed ConfigMap is a regular release resource for SQLite and a Helm hook
+  for external databases.
 - E2E tests extended to verify PAT authentication with `GET /api/groups`
   across all three database backends (SQLite, PostgreSQL, MySQL).
-- 28 new unit tests for PAT seed Job and ConfigMap templates.
-- Upgraded Initium init container image to v1.0.1 (fixes PostgreSQL inserts
-  on tables with text primary keys).
+- Unit tests for PAT seed Job, ConfigMap, and sidecar templates.
+- Upgraded Initium init container image to v1.0.4 (adds `--sidecar` flag for
+  keeping the process alive after task completion, SHA256/base64 template
+  filters, PostgreSQL text primary key fix).
 
 ### Changed
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -20,7 +20,7 @@ For external databases (PostgreSQL, MySQL), the chart automatically:
 
 ## Prerequisites
 
-- Kubernetes 1.24+
+- Kubernetes 1.24+ (1.28+ required for SQLite PAT seeding with native sidecars)
 - Helm 3.x
 - An OAuth2 / OIDC identity provider (Auth0, Keycloak, Authentik, Zitadel, etc.)
 - An Ingress controller (nginx recommended) with TLS termination
@@ -216,11 +216,24 @@ pat:
   expirationDays: 365
 ```
 
-The chart creates a post-install/post-upgrade Helm hook Job that:
-1. Waits for the server to be reachable (TCP probe via Initium `wait-for`)
-2. Waits for the `accounts`, `users`, and `personal_access_tokens` tables
-   (Initium seed `wait_for`)
-3. Idempotently inserts a service user account and PAT
+The seeding mechanism depends on the database type:
+
+- **SQLite**: The seed runs as a **native sidecar** (Kubernetes 1.28+) in the
+  server Deployment. It is declared as an init container with
+  `restartPolicy: Always` and uses the `--sidecar` flag to stay alive after
+  seeding. This is required because SQLite uses a local file and
+  ReadWriteOnce PVCs cannot be mounted by multiple pods simultaneously.
+- **PostgreSQL / MySQL**: The seed runs as a post-install/post-upgrade Helm
+  hook Job that connects to the database over the network.
+
+In both cases, the seed:
+1. Waits for the `accounts`, `users`, and `personal_access_tokens` tables
+   to exist (created by the server via GORM AutoMigrate)
+2. Idempotently inserts a service user account and PAT
+
+> **Note:** The SQLite PAT sidecar requires **Kubernetes 1.28+** for native
+> sidecar support. The sidecar stays alive after completing the seed
+> (via Initium's `--sidecar` flag), so the pod shows `2/2 Running`.
 
 ### Using the PAT
 
@@ -277,7 +290,7 @@ curl -H "Authorization: Token nbp_..." https://netbird.example.com/api/groups
 | `server.image.tag` | string | `""` (appVersion) | Server image tag |
 | `server.image.pullPolicy` | string | `"IfNotPresent"` | Image pull policy |
 | `server.initImage.repository` | string | `"ghcr.io/kitstream/initium"` | Init container image ([Initium](https://github.com/KitStream/initium)) |
-| `server.initImage.tag` | string | `"1.0.0"` | Init container image tag |
+| `server.initImage.tag` | string | `"1.0.4"` | Init container image tag |
 | `server.imagePullSecrets` | list | `[]` | Component-level pull secrets |
 
 #### Server Configuration

--- a/charts/netbird/templates/NOTES.txt
+++ b/charts/netbird/templates/NOTES.txt
@@ -37,7 +37,13 @@ Components:
 {{- if .Values.pat.enabled }}
 
   PAT Seeding: ENABLED
+  {{- if eq .Values.database.type "sqlite" }}
+    A sidecar container in the server pod will seed a Personal Access Token
+    into the SQLite database. The sidecar shares the data volume with the
+    server (required for ReadWriteOnce PVCs).
+  {{- else }}
     A post-install Job will seed a Personal Access Token into the database.
+  {{- end }}
     Secret: {{ .Values.pat.secret.secretName }}
     The plaintext PAT can be retrieved with:
       kubectl get secret {{ .Values.pat.secret.secretName }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.pat.secret.tokenKey }}}' | base64 -d

--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -290,10 +290,6 @@ phases:
                 domain: "netbird.selfhosted"
                 domain_category: "private"
                 is_domain_primary_account: 1
-                network_identifier: "seed-network"
-                network_net: "100.64.0.0/10"
-                network_dns: ""
-                network_serial: 0
       - name: pat-user
         order: 2
         tables:

--- a/charts/netbird/templates/pat-seed-configmap.yaml
+++ b/charts/netbird/templates/pat-seed-configmap.yaml
@@ -1,8 +1,13 @@
 {{/*
 ConfigMap for the PAT seed spec. Only rendered when pat.enabled is true.
 Contains the Initium seed spec that inserts account, user, and PAT records.
+
+For SQLite this is a regular release resource (consumed by the sidecar in the
+Deployment). For external databases it remains a Helm hook so the seed Job
+can reference it during the post-install/post-upgrade phase.
 */}}
 {{- if .Values.pat.enabled }}
+{{- $isExternal := eq (include "netbird.database.isExternal" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,10 +18,12 @@ metadata:
     app.kubernetes.io/name: {{ include "netbird.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: pat-seed
+  {{- if $isExternal }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation
+  {{- end }}
 data:
   pat-seed.yaml: |
     {{- include "netbird.pat.seedSpec" . | nindent 4 }}

--- a/charts/netbird/templates/pat-seed-job.yaml
+++ b/charts/netbird/templates/pat-seed-job.yaml
@@ -1,10 +1,15 @@
 {{/*
 Post-install/post-upgrade Job - seeds a Personal Access Token into the
-NetBird database via Initium seed command. Only rendered when
-pat.enabled is true.
+NetBird database via Initium seed command.
+
+Only rendered for external databases (PostgreSQL/MySQL) where the seed
+connects over the network. For SQLite the seed runs as a sidecar container
+in the server Deployment to share the same PVC (ReadWriteOnce PVCs do not
+support multi-pod attach).
 */}}
 {{- if .Values.pat.enabled }}
 {{- $isExternal := eq (include "netbird.database.isExternal" .) "true" }}
+{{- if $isExternal }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -64,20 +69,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.pat.secret.secretName }}
                   key: {{ .Values.pat.secret.hashedTokenKey }}
-            {{- if $isExternal }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.passwordSecret.secretName }}
                   key: {{ .Values.database.passwordSecret.secretKey }}
-            {{- end }}
           securityContext:
-            {{- if eq .Values.database.type "sqlite" }}
-            runAsUser: 0
-            {{- else }}
             runAsNonRoot: true
             runAsUser: 65534
-            {{- end }}
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
@@ -86,23 +85,10 @@ spec:
             - name: config
               mountPath: /spec
               readOnly: true
-            {{- if eq .Values.database.type "sqlite" }}
-            - name: data
-              mountPath: /var/lib/netbird
-            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "netbird.server.fullname" . }}-pat-seed
-        {{- if eq .Values.database.type "sqlite" }}
-        - name: data
-          {{- if .Values.server.persistentVolume.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "netbird.server.fullname" . }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-        {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -111,4 +97,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/netbird/templates/server-deployment.yaml
+++ b/charts/netbird/templates/server-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include "netbird.server.configTemplate" . | sha256sum }}
+        {{- if and .Values.pat.enabled (eq .Values.database.type "sqlite") }}
+        checksum/pat-seed: {{ include "netbird.pat.seedSpec" . | sha256sum }}
+        {{- end }}
         {{- with .Values.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -36,6 +39,7 @@ spec:
       {{- $authSecretName := include "netbird.server.resolveSecretName" (dict "ref" .Values.server.secrets.authSecret "generated" $generated) }}
       {{- $encKeySecretName := include "netbird.server.resolveSecretName" (dict "ref" .Values.server.secrets.storeEncryptionKey "generated" $generated) }}
       {{- $isExternal := eq (include "netbird.database.isExternal" .) "true" }}
+      {{- $patSidecar := and .Values.pat.enabled (not $isExternal) }}
       initContainers:
         {{- if $isExternal }}
         # ── Wait for database to be reachable ──────────────────────────
@@ -133,6 +137,40 @@ spec:
               readOnly: true
             - name: config-generated
               mountPath: /out
+        {{- if $patSidecar }}
+        # ── PAT seed native sidecar (SQLite only) ────────────────────────
+        # Declared as an init container with restartPolicy: Always, making
+        # it a Kubernetes native sidecar (K8s 1.28+). It starts alongside
+        # the server and stays alive after seeding (--sidecar flag).
+        # Required because ReadWriteOnce PVCs do not support multi-pod
+        # attach, so a separate Job cannot mount the PVC.
+        - name: pat-seed
+          restartPolicy: Always
+          image: "{{ .Values.server.initImage.repository }}:{{ .Values.server.initImage.tag }}"
+          args:
+            - --sidecar
+            - seed
+            - --spec
+            - /spec/pat-seed.yaml
+          env:
+            - name: PAT_HASHED_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.pat.secret.secretName }}
+                  key: {{ .Values.pat.secret.hashedTokenKey }}
+          securityContext:
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: pat-seed-config
+              mountPath: /spec
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/netbird
+        {{- end }}
       containers:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
@@ -182,6 +220,11 @@ spec:
             name: {{ include "netbird.server.fullname" . }}
         - name: config-generated
           emptyDir: {}
+        {{- if $patSidecar }}
+        - name: pat-seed-config
+          configMap:
+            name: {{ include "netbird.server.fullname" . }}-pat-seed
+        {{- end }}
         - name: data
           {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:

--- a/charts/netbird/tests/pat-seed-configmap_test.yaml
+++ b/charts/netbird/tests/pat-seed-configmap_test.yaml
@@ -17,10 +17,26 @@ tests:
       - isKind:
           of: ConfigMap
 
-  - it: should have helm hook annotations
+  # ── Hook annotations: only for external databases ──────────────────
+
+  - it: should not have helm hook annotations for sqlite
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: should have helm hook annotations for postgresql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
@@ -28,6 +44,22 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "0"
+
+  - it: should have helm hook annotations for mysql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: mysql
+      database.host: mysql.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: mysql-secret
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-install,post-upgrade"
+
+  # ── Seed spec content ──────────────────────────────────────────────
 
   - it: should contain pat-seed.yaml key
     set:
@@ -136,4 +168,3 @@ tests:
       - matchRegex:
           path: data["pat-seed.yaml"]
           pattern: "table: personal_access_tokens"
-

--- a/charts/netbird/tests/pat-seed-job_test.yaml
+++ b/charts/netbird/tests/pat-seed-job_test.yaml
@@ -16,12 +16,53 @@ tests:
       - hasDocuments:
           count: 0
 
-  # ── Basic rendering ─────────────────────────────────────────────────
+  # ── Not rendered for SQLite (uses sidecar instead) ─────────────────
 
-  - it: should render a Job when pat.enabled is true
+  - it: should not render for sqlite even when pat.enabled is true
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render for sqlite with PV enabled
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+      server.persistentVolume.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── Basic rendering (external DB only) ─────────────────────────────
+
+  - it: should render a Job for postgresql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+
+  - it: should render a Job for mysql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: mysql
+      database.host: mysql.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: mysql-secret
     asserts:
       - hasDocuments:
           count: 1
@@ -32,6 +73,11 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
@@ -47,6 +93,11 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
@@ -58,13 +109,18 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-server
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.1"
+          value: "ghcr.io/kitstream/initium:1.0.4"
       - contains:
           path: spec.template.spec.initContainers[0].args
           content: "tcp://RELEASE-NAME-netbird-server:80"
@@ -73,6 +129,11 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
@@ -87,19 +148,29 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
           value: pat-seed
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.1"
+          value: "ghcr.io/kitstream/initium:1.0.4"
 
   - it: should inject PAT_HASHED_TOKEN env var from secret
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
       pat.secret.hashedTokenKey: myHashKey
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -109,18 +180,6 @@ tests:
               secretKeyRef:
                 name: my-pat-secret
                 key: myHashKey
-
-  - it: should not inject DB_PASSWORD for sqlite
-    set:
-      pat.enabled: true
-      pat.secret.secretName: my-pat-secret
-      database.type: sqlite
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DB_PASSWORD
-          any: true
 
   - it: should inject DB_PASSWORD for postgresql
     set:
@@ -165,6 +224,11 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -172,18 +236,6 @@ tests:
             name: config
             mountPath: /spec
             readOnly: true
-
-  - it: should mount data volume for sqlite
-    set:
-      pat.enabled: true
-      pat.secret.secretName: my-pat-secret
-      database.type: sqlite
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            name: data
-            mountPath: /var/lib/netbird
 
   - it: should not mount data volume for postgresql
     set:
@@ -201,12 +253,34 @@ tests:
             name: data
             mountPath: /var/lib/netbird
 
+  - it: should run non-root for external databases
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65534
+
   # ── Volumes ──────────────────────────────────────────────────────────
 
   - it: should have config volume from configmap
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -221,6 +295,11 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: spec.backoffLimit
@@ -233,8 +312,12 @@ tests:
     set:
       pat.enabled: true
       pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
     asserts:
       - equal:
           path: spec.template.spec.restartPolicy
           value: OnFailure
-

--- a/charts/netbird/tests/server-deployment_test.yaml
+++ b/charts/netbird/tests/server-deployment_test.yaml
@@ -144,9 +144,9 @@ tests:
           value: config-init
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.1"
+          value: "ghcr.io/kitstream/initium:1.0.4"
 
-  - it: should have only config-init for sqlite
+  - it: should have only config-init for sqlite without pat
     asserts:
       - lengthEqual:
           path: spec.template.spec.initContainers
@@ -329,6 +329,210 @@ tests:
           path: spec.template.spec.initContainers[2].securityContext.runAsNonRoot
           value: true
 
+  # ── PAT seed native sidecar (SQLite only) ──────────────────────────
+
+  - it: should have only one container (server) when pat is disabled
+    set:
+      pat.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+
+  - it: should have only one container (server) even with pat enabled for sqlite
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+
+  - it: should add pat-seed native sidecar as init container for sqlite
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: config-init
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: pat-seed
+
+  - it: should set restartPolicy Always on pat-seed native sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].restartPolicy
+          value: Always
+
+  - it: should use initium image for pat-seed sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: "ghcr.io/kitstream/initium:1.0.4"
+
+  - it: should run seed command with --sidecar flag in pat-seed sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].args
+          value:
+            - --sidecar
+            - seed
+            - --spec
+            - /spec/pat-seed.yaml
+
+  - it: should inject PAT_HASHED_TOKEN into sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      pat.secret.hashedTokenKey: myHash
+      database.type: sqlite
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: PAT_HASHED_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-pat-secret
+                key: myHash
+
+  - it: should run sidecar as root for SQLite PVC access
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should mount pat-seed-config and data volumes on sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          content:
+            name: pat-seed-config
+            mountPath: /spec
+            readOnly: true
+      - contains:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          content:
+            name: data
+            mountPath: /var/lib/netbird
+
+  - it: should not add pat-seed sidecar for postgresql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 3
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: db-wait
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: db-seed
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: config-init
+
+  - it: should add pat-seed-config volume for sqlite pat sidecar
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: pat-seed-config
+            configMap:
+              name: RELEASE-NAME-netbird-server-pat-seed
+
+  - it: should not add pat-seed-config volume when pat is disabled
+    set:
+      pat.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: pat-seed-config
+          any: true
+
+  - it: should not add pat-seed-config volume for postgresql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: pat-seed-config
+          any: true
+
+  - it: should include pat-seed checksum annotation for sqlite
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: sqlite
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations.checksum/pat-seed
+
+  - it: should not include pat-seed checksum for postgresql
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+      database.type: postgresql
+      database.host: pg.example.com
+      database.user: netbird
+      database.name: netbird
+      database.passwordSecret.secretName: pg-secret
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations.checksum/pat-seed
+
   # ── Other deployment settings ────────────────────────────────────────
 
   - it: should set resource limits when specified
@@ -398,5 +602,3 @@ tests:
           path: spec.template.spec.containers[0].securityContext
           value:
             readOnlyRootFilesystem: true
-
-

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -150,7 +150,7 @@ server:
     # -- Init container image repository.
     repository: ghcr.io/kitstream/initium
     # -- Init container image tag.
-    tag: "1.0.1"
+    tag: "1.0.4"
 
   # -- Component-level image pull secrets.
   imagePullSecrets: []

--- a/ci/scripts/e2e.sh
+++ b/ci/scripts/e2e.sh
@@ -219,9 +219,15 @@ if ! helm install "$RELEASE" "$CHART" \
   --set pat.secret.secretName=netbird-pat \
   "${EXTRA_SETS[@]}" \
   --timeout "$TIMEOUT"; then
-  log "Helm install failed — dumping PAT seed job logs..."
-  kubectl -n "$NAMESPACE" logs job/"$RELEASE"-server-pat-seed --all-containers 2>/dev/null || true
-  kubectl -n "$NAMESPACE" describe job/"$RELEASE"-server-pat-seed 2>/dev/null || true
+  log "Helm install failed — dumping logs..."
+  if [ "$BACKEND" = "sqlite" ]; then
+    log "PAT seed sidecar logs:"
+    kubectl -n "$NAMESPACE" logs deployment/"$RELEASE"-server -c pat-seed 2>/dev/null || true
+  else
+    log "PAT seed job logs:"
+    kubectl -n "$NAMESPACE" logs job/"$RELEASE"-server-pat-seed --all-containers 2>/dev/null || true
+    kubectl -n "$NAMESPACE" describe job/"$RELEASE"-server-pat-seed 2>/dev/null || true
+  fi
   fail "Helm install failed"
 fi
 
@@ -237,14 +243,37 @@ kubectl -n "$NAMESPACE" get pods -o wide
 log "Running helm test..."
 helm test "$RELEASE" -n "$NAMESPACE" --timeout 2m
 
-# ── Wait for PAT seed job to complete ─────────────────────────────────
-log "Waiting for PAT seed job to complete..."
-kubectl -n "$NAMESPACE" wait --for=condition=complete \
-  job/"$RELEASE"-server-pat-seed --timeout=180s || {
-  log "PAT seed job logs:"
-  kubectl -n "$NAMESPACE" logs job/"$RELEASE"-server-pat-seed --all-containers || true
-  fail "PAT seed job did not complete"
-}
+# ── Wait for PAT seed to complete ─────────────────────────────────────
+if [ "$BACKEND" = "sqlite" ]; then
+  # SQLite: PAT seed runs as a native sidecar (init container with
+  # restartPolicy: Always) in the server pod. The sidecar stays alive
+  # after seeding (--sidecar flag), so we check its logs for the
+  # "seed execution completed" message rather than waiting for
+  # container termination.
+  log "Waiting for PAT seed native sidecar to complete seeding..."
+  for i in $(seq 1 60); do
+    LOGS=$(kubectl -n "$NAMESPACE" logs deployment/"$RELEASE"-server -c pat-seed 2>/dev/null || echo "")
+    if echo "$LOGS" | grep -q "seed execution completed"; then
+      log "PAT seed sidecar completed seeding successfully"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      log "PAT seed sidecar logs:"
+      echo "$LOGS"
+      fail "PAT seed sidecar did not complete seeding within timeout"
+    fi
+    sleep 3
+  done
+else
+  # External DB: PAT seed runs as a separate hook Job.
+  log "Waiting for PAT seed job to complete..."
+  kubectl -n "$NAMESPACE" wait --for=condition=complete \
+    job/"$RELEASE"-server-pat-seed --timeout=180s || {
+    log "PAT seed job logs:"
+    kubectl -n "$NAMESPACE" logs job/"$RELEASE"-server-pat-seed --all-containers || true
+    fail "PAT seed job did not complete"
+  }
+fi
 # ── Verify PAT authentication ─────────────────────────────────────────
 log "Verifying PAT authentication against API..."
 # Re-derive the PAT_TOKEN (same deterministic generation as above)


### PR DESCRIPTION
## Overview

Add Personal Access Token (PAT) seeding capability to the NetBird Helm chart using Initium v1.0.4. Enables immediate API access without manual token creation — useful for automation, CI/CD, and GitOps workflows.

## Key Features

### PAT Seeding Mechanism
- **SQLite**: Native sidecar (init container with `restartPolicy: Always`, K8s 1.28+) in the server Deployment
  - Shares data volume with server (solves ReadWriteOnce PVC multi-attach issues)
  - Uses `--sidecar` flag to stay alive after seeding
  - Pod shows `2/2 Running` when healthy
- **PostgreSQL/MySQL**: Post-install/post-upgrade Helm hook Job with TCP readiness check

### Seed Behavior
- Waits for `accounts`, `users`, and `personal_access_tokens` tables (via GORM AutoMigrate)
- Idempotently inserts service user account and PAT (safe on re-installs)
- Uses MiniJinja templates for secure token/hash injection via env vars

### Configuration (values.yaml)
- `pat.enabled`: Enable/disable PAT seeding
- `pat.secret.secretName`: K8s Secret containing plaintext PAT and base64 SHA256 hash
- `pat.name`, `pat.userId`, `pat.accountId`: Configurable identifiers
- `pat.expirationDays`: Token validity period (default 365)

## Changes

- **New templates**: `pat-seed-configmap.yaml`, `pat-seed-job.yaml`
- **Updated**: `server-deployment.yaml` with native sidecar support
- **Helpers**: `_helpers.tpl` with PAT seed spec generation
- **Testing**: 148 unit tests (configmap, job, deployment integration)
- **E2E**: Updated `ci/scripts/e2e.sh` with PAT generation and authentication verification
- **Dependency**: Upgraded Initium to v1.0.4 (adds `--sidecar` flag, text PK fixes)
- **Database compatibility**: Boolean/datetime formats for MySQL tinyint and compatibility

## Breaking Changes

None. PAT seeding is opt-in (`pat.enabled: false` by default).

## Testing

- SQLite, PostgreSQL, MySQL all tested with PAT authentication
- `curl -H "Authorization: Token nbp_..." https://netbird.example.com/api/groups` verified
- Pod readiness, logs, and seed completion validated in e2e tests

Closes https://github.com/KitStream/helms/issues/3