### PR TITLE
fix(netbird): set default values for NULL columns in PAT seed

### DIFF
--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -409,9 +409,24 @@ phases:
             rows:
               - id: {{ .Values.pat.accountId | quote }}
                 created_by: "helm-seed"
+                created_at: {{ now | date "2006-01-02 15:04:05" | quote }}
                 domain: "netbird.selfhosted"
                 domain_category: "private"
                 is_domain_primary_account: 1
+                network_net: '{"IP":"100.64.0.0","Mask":"//AAAA=="}'
+                network_serial: 0
+                dns_settings_disabled_management_groups: "[]"
+                settings_peer_login_expiration_enabled: 1
+                settings_peer_login_expiration: 86400000000000
+                settings_peer_inactivity_expiration_enabled: 0
+                settings_peer_inactivity_expiration: 600000000000
+                settings_regular_users_view_blocked: 1
+                settings_groups_propagation_enabled: 1
+                settings_jwt_groups_enabled: 0
+                settings_routing_peer_dns_resolution_enabled: 1
+                settings_peer_expose_enabled: 0
+                settings_extra_peer_approval_enabled: 0
+                settings_extra_user_approval_required: 1
       - name: pat-user
         order: 2
         tables:
@@ -425,7 +440,10 @@ phases:
                 service_user_name: "helm-seed-service-user"
                 non_deletable: 0
                 blocked: 0
+                pending_approval: 0
                 issued: "api"
+                integration_ref_id: 0
+                integration_ref_integration_type: ""
       - name: pat-token
         order: 3
         tables:

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,7 +62,7 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.1.2
+            helm.sh/chart: netbird-0.1.3
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: "0.66.3"
 


### PR DESCRIPTION
## Summary
- Set explicit default values for all NOT NULL integer, boolean, and string columns in the seeded `accounts` and `users` rows
- Fixes `cannot scan NULL into *int` error on PostgreSQL/MySQL when peers attempt gRPC login against a Helm-seeded account
- Accounts row: adds defaults for `network_serial`, `network_net`, `dns_settings_disabled_management_groups`, and all 11 `settings_*` columns
- Users row: adds defaults for `pending_approval`, `integration_ref_id`, `integration_ref_integration_type`
- Updates serviceaccount test to match chart version 0.1.3

## Test plan
- [x] `helm unittest` — 190 tests pass
- [x] `make e2e-sqlite` — PASSED (peer registration, no scan errors)
- [x] `make e2e-postgres` — PASSED (peer registration, no scan errors)
- [x] `make e2e-mysql` — PASSED (peer registration, no scan errors)
- [x] Manually verified server logs are clean (no `scan NULL` errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)