### PR TITLE
feat(netbird): upgrade Initium to v1.2.0 with reconcile mode

### DIFF
--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -370,7 +370,9 @@ The seed waits for the personal_access_tokens table (created by NetBird
 on startup via GORM AutoMigrate), then idempotently inserts the
 account, user, PAT, "All" group, default policy, and default policy
 rule records.
-MiniJinja placeholders (Initium v1.0.4+):
+Seed sets use mode: reconcile (Initium v1.2.0+) so that value
+changes in the Helm chart are reflected in the database on upgrade.
+MiniJinja placeholders:
   {{ env.PAT_TOKEN | sha256("bytes") | base64_encode }} — computes the
   base64-encoded SHA256 hash from the plaintext PAT at seed time.
 */}}
@@ -402,6 +404,7 @@ phases:
         timeout: 120s
     seed_sets:
       - name: pat-account
+        mode: reconcile
         order: 1
         tables:
           - table: accounts
@@ -428,6 +431,7 @@ phases:
                 settings_extra_peer_approval_enabled: 0
                 settings_extra_user_approval_required: 1
       - name: pat-user
+        mode: reconcile
         order: 2
         tables:
           - table: users
@@ -445,6 +449,7 @@ phases:
                 integration_ref_id: 0
                 integration_ref_integration_type: ""
       - name: pat-token
+        mode: reconcile
         order: 3
         tables:
           - table: personal_access_tokens
@@ -458,6 +463,7 @@ phases:
                 created_by: {{ .Values.pat.userId | quote }}
                 created_at: {{ now | date "2006-01-02 15:04:05" | quote }}
       - name: pat-all-group
+        mode: reconcile
         order: 4
         tables:
           - table: groups
@@ -468,6 +474,7 @@ phases:
                 name: "All"
                 issued: "api"
       - name: pat-default-policy
+        mode: reconcile
         order: 5
         tables:
           - table: policies
@@ -479,6 +486,7 @@ phases:
                 description: "This is a default policy that allows connections between all the resources"
                 enabled: 1
       - name: pat-default-policy-rule
+        mode: reconcile
         order: 6
         tables:
           - table: policy_rules

--- a/charts/netbird/tests/pat-seed-configmap_test.yaml
+++ b/charts/netbird/tests/pat-seed-configmap_test.yaml
@@ -154,6 +154,15 @@ tests:
           path: data["pat-seed.yaml"]
           pattern: "name: policy_rules"
 
+  - it: should use reconcile mode on seed sets
+    set:
+      pat.enabled: true
+      pat.secret.secretName: my-pat-secret
+    asserts:
+      - matchRegex:
+          path: data["pat-seed.yaml"]
+          pattern: "mode: reconcile"
+
   - it: should compute hashed_token from PAT_TOKEN via sha256 and base64_encode
     set:
       pat.enabled: true

--- a/charts/netbird/tests/pat-seed-job_test.yaml
+++ b/charts/netbird/tests/pat-seed-job_test.yaml
@@ -120,7 +120,7 @@ tests:
           value: wait-server
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.4"
+          value: "ghcr.io/kitstream/initium:1.2.0"
       - contains:
           path: spec.template.spec.initContainers[0].args
           content: "tcp://RELEASE-NAME-netbird-server:80"
@@ -159,7 +159,7 @@ tests:
           value: pat-seed
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.4"
+          value: "ghcr.io/kitstream/initium:1.2.0"
 
   - it: should inject PAT_TOKEN env var from secret
     set:

--- a/charts/netbird/tests/server-deployment_test.yaml
+++ b/charts/netbird/tests/server-deployment_test.yaml
@@ -144,7 +144,7 @@ tests:
           value: config-init
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/kitstream/initium:1.0.4"
+          value: "ghcr.io/kitstream/initium:1.2.0"
 
   - it: should have only config-init for sqlite without pat
     asserts:
@@ -383,7 +383,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "ghcr.io/kitstream/initium:1.0.4"
+          value: "ghcr.io/kitstream/initium:1.2.0"
 
   - it: should run seed command with --sidecar flag in pat-seed sidecar
     set:

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -277,7 +277,7 @@ server:
     # -- Init container image repository.
     repository: ghcr.io/kitstream/initium
     # -- Init container image tag.
-    tag: "1.0.4"
+    tag: "1.2.0"
 
   # -- Component-level image pull secrets.
   imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Upgrade Initium from v1.0.4 to v1.2.0
- Enable `mode: reconcile` on all 6 PAT seed sets, making them declarative — Initium will insert, update, or delete rows to match the spec on each run
- This ensures PAT seed data stays in sync when Helm values change

## Test plan
- [x] All 191 helm unit tests pass
- [ ] E2E test with SQLite, PostgreSQL, and MySQL backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)