### PR TITLE
fix(ci): remove flawed HEAD~1 diff check in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,12 +45,6 @@ jobs:
               continue
             fi
 
-            # Check if Chart.yaml was actually changed in this push
-            if ! git diff HEAD~1 --name-only -- "$chart_yaml" | grep -q .; then
-              echo "Chart.yaml not changed for ${chart_name} — skipping"
-              continue
-            fi
-
             echo "::group::Releasing ${chart_name} v${version}"
 
             # Login to GHCR


### PR DESCRIPTION
## Summary

- Remove the `git diff HEAD~1` check from the release workflow that was causing releases to be silently skipped
- For merge commits, `HEAD~1` points to the previous main commit, not the PR branch, so the diff never shows Chart.yaml as changed
- The remaining two guards are sufficient: `paths` filter (only triggers when Chart.yaml changes) + tag existence check (idempotent)

## Test plan

- [ ] Merge this PR, then merge the netbird v0.2.0 release PR (#20) — verify the release workflow triggers and completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)