### PR TITLE
feat(ci): add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'charts/*/Chart.yaml'
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to the release workflow so it can be manually run
- Needed to release netbird v0.2.0, which was merged before the workflow fix landed

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger the release workflow: `gh workflow run release.yaml`
- [ ] Verify netbird-0.2.0 tag and GitHub release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)