### PR TITLE
chore: prepare netbird v0.2.1 release

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netbird
 description: A Helm chart for deploying NetBird VPN management, signal, dashboard, and relay services on Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.66.3"
 keywords:
   - netbird
@@ -30,8 +30,10 @@ annotations:
     - name: Initium
       url: https://github.com/KitStream/initium
   artifacthub.io/changes: |
-    - kind: added
-      description: Upgrade Initium to v1.2.0 and enable reconcile mode on PAT seed sets
     - kind: fixed
-      description: Set default values for all NOT NULL columns in PAT seed
+      description: Use in-cluster exposedAddress and verify accessible peers
+    - kind: fixed
+      description: Use busybox wget in provision script, add E2E wait for provisioning
+    - kind: fixed
+      description: Create group and policy via API instead of direct DB seed
 

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,7 +62,7 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.2.0
+            helm.sh/chart: netbird-0.2.1
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: "0.66.3"
 


### PR DESCRIPTION
## Summary
- Bump netbird chart version from 0.2.0 to 0.2.1 (patch)
- Update artifacthub.io/changes annotations with changelog entries
- Fix hardcoded chart version in serviceaccount test

## Changelog
- **fixed**: Use in-cluster exposedAddress and verify accessible peers
- **fixed**: Use busybox wget in provision script, add E2E wait for provisioning
- **fixed**: Create group and policy via API instead of direct DB seed

## Test plan
- [x] `make test` passes (all 193 tests, 15 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)