### PR TITLE
chore: prepare netbird v0.3.3 release

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netbird
 description: A Helm chart for deploying NetBird VPN management, signal, dashboard, and relay services on Kubernetes
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.67.1"
 keywords:
   - netbird

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,6 +62,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.3.2
+            helm.sh/chart: netbird-0.3.3
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: "0.67.1"


### PR DESCRIPTION
## Summary
- Bump netbird chart version from 0.3.2 to 0.3.3
- Includes appVersion bump from 0.67.0 to 0.67.1

## Test plan
- [x] `make test` — all 193 netbird tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)