### PR TITLE
chore: prepare keycloak v26.5.7 release

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -6,6 +6,6 @@ All notable changes to the Keycloak Helm chart will be documented in this file.
 
 ### Changed
 
-- Bump Keycloak appVersion from 26.5.0 to 26.5.6 (security and bugfix release)
-  - Includes 8 security fixes (CVEs) and 11 bug fixes
-  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.5.6) for details
+- Bump Keycloak appVersion from 26.5.6 to 26.5.7 (security and bugfix release)
+  - Includes 7 CVE fixes and 1 bug fix
+  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.5.7) for details

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak
 description: A Helm chart for deploying Keycloak IAM using the upstream quay.io/keycloak/keycloak image on Kubernetes
 type: application
-version: 26.5.6
-appVersion: "26.5.6"
+version: 26.5.7
+appVersion: "26.5.7"
 keywords:
   - keycloak
   - iam
@@ -31,6 +31,6 @@ annotations:
       url: https://github.com/KitStream/helms
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump Keycloak from 26.5.0 to 26.5.6 (security and bugfix release)
+      description: Bump Keycloak from 26.5.6 to 26.5.7 (security and bugfix release)
     - kind: security
-      description: Includes 8 upstream CVE fixes (see Keycloak 26.5.1–26.5.6 release notes)
+      description: Includes 7 upstream CVE fixes (see Keycloak 26.5.7 release notes)

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.5.6"
+          value: "quay.io/keycloak/keycloak:26.5.7"
 
   - it: should use custom image tag when set
     set:
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "my-registry/keycloak:26.5.6"
+          value: "my-registry/keycloak:26.5.7"
 
   - it: should set replica count
     set:
@@ -262,7 +262,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "quay.io/keycloak/keycloak:26.5.6"
+          value: "quay.io/keycloak/keycloak:26.5.7"
 
   - it: should set hardened securityContext on build init container
     set:

--- a/charts/keycloak/tests/serviceaccount_test.yaml
+++ b/charts/keycloak/tests/serviceaccount_test.yaml
@@ -52,6 +52,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: keycloak-26.5.6
+            helm.sh/chart: keycloak-26.5.7
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "26.5.6"
+            app.kubernetes.io/version: "26.5.7"


### PR DESCRIPTION
## Summary

- Bump Keycloak appVersion and chart version from 26.5.6 to 26.5.7
- Upstream security release with 7 CVE fixes and 1 bug fix
- Updated test assertions and changelog

Closes #57

## How to verify

```bash
make test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)