### PR TITLE
chore: prepare netbird v0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [0.3.4] — 2026-04-09
+
+### Changed
+
+- **netbird**: Bump appVersion from 0.67.1 to 0.67.4.
+  See [v0.67.4 release notes](https://github.com/netbirdio/netbird/releases/tag/v0.67.4).
+
 ## [0.3.2] — 2026-03-28
 
 ### Changed

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netbird
 description: A Helm chart for deploying NetBird VPN management, signal, dashboard, and relay services on Kubernetes
 type: application
-version: 0.3.3
-appVersion: "0.67.1"
+version: 0.3.4
+appVersion: "0.67.4"
 keywords:
   - netbird
   - vpn
@@ -31,4 +31,4 @@ annotations:
       url: https://github.com/KitStream/initium
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump NetBird from 0.67.0 to 0.67.1
+      description: Bump NetBird from 0.67.1 to 0.67.4

--- a/charts/netbird/tests/server-deployment_test.yaml
+++ b/charts/netbird/tests/server-deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "netbirdio/netbird-server:0.67.1"
+          value: "netbirdio/netbird-server:0.67.4"
 
   - it: should use custom image tag when set
     set:

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,6 +62,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.3.3
+            helm.sh/chart: netbird-0.3.4
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "0.67.1"
+            app.kubernetes.io/version: "0.67.4"


### PR DESCRIPTION
## Summary

- Bump NetBird appVersion from 0.67.1 to 0.67.4
- Bump chart version from 0.3.3 to 0.3.4

Closes #58

## Test plan

- [x] `make test` — all 295 tests pass (lint + unit)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)