### PR TITLE
chore: prepare keycloak v26.6.0 release

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Keycloak Helm chart will be documented in this file.
 
 ### Changed
 
-- Bump Keycloak appVersion from 26.5.6 to 26.5.7 (security and bugfix release)
-  - Includes 7 CVE fixes and 1 bug fix
-  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.5.7) for details
+- Bump Keycloak appVersion from 26.5.7 to 26.6.0 (feature release)
+  - JWT Authorization Grant, Federated client authentication, Workflows now fully supported
+  - Zero-downtime patch releases
+  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.6.0) for details

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak
 description: A Helm chart for deploying Keycloak IAM using the upstream quay.io/keycloak/keycloak image on Kubernetes
 type: application
-version: 26.5.7
-appVersion: "26.5.7"
+version: 26.6.0
+appVersion: "26.6.0"
 keywords:
   - keycloak
   - iam
@@ -31,6 +31,6 @@ annotations:
       url: https://github.com/KitStream/helms
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump Keycloak from 26.5.6 to 26.5.7 (security and bugfix release)
-    - kind: security
-      description: Includes 7 upstream CVE fixes (see Keycloak 26.5.7 release notes)
+      description: Bump Keycloak from 26.5.7 to 26.6.0 (feature release)
+    - kind: added
+      description: "Upstream highlights: JWT Authorization Grant, Federated client authentication, Workflows, zero-downtime patch releases"

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.5.7"
+          value: "quay.io/keycloak/keycloak:26.6.0"
 
   - it: should use custom image tag when set
     set:
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "my-registry/keycloak:26.5.7"
+          value: "my-registry/keycloak:26.6.0"
 
   - it: should set replica count
     set:
@@ -262,7 +262,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "quay.io/keycloak/keycloak:26.5.7"
+          value: "quay.io/keycloak/keycloak:26.6.0"
 
   - it: should set hardened securityContext on build init container
     set:

--- a/charts/keycloak/tests/serviceaccount_test.yaml
+++ b/charts/keycloak/tests/serviceaccount_test.yaml
@@ -52,6 +52,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: keycloak-26.5.7
+            helm.sh/chart: keycloak-26.6.0
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "26.5.7"
+            app.kubernetes.io/version: "26.6.0"


### PR DESCRIPTION
## Summary

- Bump Keycloak appVersion and chart version from 26.5.7 to 26.6.0
- Upstream feature release: JWT Authorization Grant, Federated client authentication, Workflows, zero-downtime patch releases
- Updated test assertions and changelog

Closes #60

## How to verify

```bash
make test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)