### PR TITLE
fix(keycloak): update broken icon URL for Artifact Hub (#64)

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Keycloak Helm chart will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Fix broken chart icon URL — upstream Keycloak moved `keycloak_icon_512px.svg` to `icon.svg` (#64)
+
 ### Changed
 
 - Bump Keycloak appVersion from 26.5.7 to 26.6.0 (feature release)

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 maintainers:
   - name: KitStream
     url: https://github.com/KitStream
-icon: https://www.keycloak.org/resources/images/keycloak_icon_512px.svg
+icon: https://www.keycloak.org/resources/images/icon.svg
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |


### PR DESCRIPTION
## Summary

- Update Keycloak chart `icon` URL from `keycloak_icon_512px.svg` to `icon.svg` — upstream Keycloak moved the file, causing Artifact Hub to report 404 errors
- Add CHANGELOG entry under Unreleased > Fixed

Closes #64

## How to verify

```bash
# Confirm new URL resolves
curl -sI https://www.keycloak.org/resources/images/icon.svg | head -1
# → HTTP/2 200

make lint      # 0 charts failed
make unittest  # 102 keycloak tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)