### PR TITLE
chore: prepare netbird v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [0.4.1] — 2026-04-14
+
 ### Added
 
 - **netbird**: Document STUN networking setup in README — explains why STUN
   needs a separate service (UDP), and covers options for LoadBalancer,
   shared static IP, and NodePort configurations (#67).
+
+### Changed
+
+- **netbird**: Bump appVersion from 0.68.1 to 0.68.2.
+  See [v0.68.2 release notes](https://github.com/netbirdio/netbird/releases/tag/v0.68.2) (#69).
 
 ## [0.4.0] — 2026-04-09
 

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netbird
 description: A Helm chart for deploying NetBird VPN management, signal, dashboard, and relay services on Kubernetes
 type: application
-version: 0.4.0
-appVersion: "0.68.1"
+version: 0.4.1
+appVersion: "0.68.2"
 keywords:
   - netbird
   - vpn
@@ -31,4 +31,6 @@ annotations:
       url: https://github.com/KitStream/initium
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump NetBird from 0.67.4 to 0.68.1
+      description: Bump NetBird from 0.68.1 to 0.68.2
+    - kind: changed
+      description: Document STUN networking setup in README

--- a/charts/netbird/tests/server-deployment_test.yaml
+++ b/charts/netbird/tests/server-deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "netbirdio/netbird-server:0.68.1"
+          value: "netbirdio/netbird-server:0.68.2"
 
   - it: should use custom image tag when set
     set:

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,6 +62,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.4.0
+            helm.sh/chart: netbird-0.4.1
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "0.68.1"
+            app.kubernetes.io/version: "0.68.2"


### PR DESCRIPTION
## Summary
- Bump netbird chart 0.4.0 → 0.4.1
- Bump appVersion 0.68.1 → 0.68.2 (closes #69)
- Include STUN networking docs from #67

## Test plan
- [x] `make test` (lint + 193 unit tests pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)