### PR TITLE
Netbird: add stunService.nodePort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- **netbird**: Add `server.stunService.nodePort` value to allow specifying a
+  fixed NodePort number when `server.stunService.type` is `NodePort`.
+
 ## [0.4.2] — 2026-04-21
 
 ### Added

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -278,6 +278,16 @@ server:
     port: 3478
 ```
 
+To pin a specific NodePort instead of letting Kubernetes assign one automatically:
+
+```yaml
+server:
+  stunService:
+    type: NodePort
+    port: 3478
+    nodePort: 30478
+```
+
 Point DNS at one or more node IPs. Clients will connect on the allocated
 NodePort (check `kubectl get svc` for the assigned port).
 
@@ -646,6 +656,7 @@ ADFS) can be tested manually:
 | `server.service.port`            | int    | `80`             | Server service port      |
 | `server.stunService.type`        | string | `"LoadBalancer"` | STUN service type        |
 | `server.stunService.port`        | int    | `3478`           | STUN service port        |
+| `server.stunService.nodePort`    | int    | `null`           | Fixed NodePort number    |
 | `server.stunService.annotations` | object | `{}`             | STUN service annotations |
 
 #### Server Ingress

--- a/charts/netbird/templates/server-stun-service.yaml
+++ b/charts/netbird/templates/server-stun-service.yaml
@@ -16,6 +16,9 @@ spec:
       port: {{ .Values.server.stunService.port }}
       targetPort: stun
       protocol: UDP
+      {{- if and (eq .Values.server.stunService.type "NodePort") (not (kindIs "invalid" .Values.server.stunService.nodePort)) }}
+      nodePort: {{ .Values.server.stunService.nodePort }}
+      {{- end }}
   selector:
     {{- include "netbird.server.selectorLabels" . | nindent 4 }}
 

--- a/charts/netbird/tests/server-stun-service_test.yaml
+++ b/charts/netbird/tests/server-stun-service_test.yaml
@@ -43,6 +43,35 @@ tests:
           path: spec.type
           value: NodePort
 
+  - it: should set nodePort when type is NodePort and nodePort is specified
+    set:
+      server.stunService.type: NodePort
+      server.stunService.nodePort: 30478
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: stun
+            port: 3478
+            targetPort: stun
+            protocol: UDP
+            nodePort: 30478
+
+  - it: should not set nodePort for LoadBalancer type even if nodePort is specified
+    set:
+      server.stunService.type: LoadBalancer
+      server.stunService.nodePort: 30478
+    asserts:
+      - isNull:
+          path: spec.ports[0].nodePort
+
+  - it: should not set nodePort for NodePort type when nodePort is not specified
+    set:
+      server.stunService.type: NodePort
+    asserts:
+      - isNull:
+          path: spec.ports[0].nodePort
+
   - it: should include selector labels
     asserts:
       - isSubset:

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -421,6 +421,9 @@ server:
   stunService:
     type: LoadBalancer
     port: 3478
+    # -- Optional nodePort for NodePort service type (valid range: 30000–32767).
+    # Omit or set to null to let Kubernetes allocate automatically.
+    nodePort: null
     annotations: {}
 
   # -- Ingress for HTTP routes (API + OAuth2).


### PR DESCRIPTION
adds stunService.nodePort

I like specifying `NodePort`.  
I could not do this with the existing chart.

```yaml
server:
  stunService:
    type: NodePort
    port: 3478
    nodePort: 30478
```