### PR TITLE
chore: prepare keycloak v26.6.1 release

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to the Keycloak Helm chart will be documented in this file.
 
 - Fix broken chart icon URL — upstream Keycloak moved `keycloak_icon_512px.svg` to `icon.svg` (#64)
 
-### Changed
+### Security
 
-- Bump Keycloak appVersion from 26.5.7 to 26.6.0 (feature release)
-  - JWT Authorization Grant, Federated client authentication, Workflows now fully supported
-  - Zero-downtime patch releases
-  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.6.0) for details
+- Bump Keycloak appVersion from 26.6.0 to 26.6.1 (security and bugfix release)
+  - CVE-2026-4366: Blind Server-Side Request Forgery (SSRF) via HTTP redirect handling
+  - CVE-2026-4633: User enumeration via identity-first login
+  - Includes additional bugfixes (see upstream release notes)
+  - See [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.6.1) for details

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak
 description: A Helm chart for deploying Keycloak IAM using the upstream quay.io/keycloak/keycloak image on Kubernetes
 type: application
-version: 26.6.0
-appVersion: "26.6.0"
+version: 26.6.1
+appVersion: "26.6.1"
 keywords:
   - keycloak
   - iam
@@ -31,6 +31,8 @@ annotations:
       url: https://github.com/KitStream/helms
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump Keycloak from 26.5.7 to 26.6.0 (feature release)
-    - kind: added
-      description: "Upstream highlights: JWT Authorization Grant, Federated client authentication, Workflows, zero-downtime patch releases"
+      description: Bump Keycloak from 26.6.0 to 26.6.1 (security and bugfix release)
+    - kind: security
+      description: "Upstream security fixes: CVE-2026-4366 (SSRF via HTTP redirect), CVE-2026-4633 (user enumeration via identity-first login)"
+    - kind: fixed
+      description: Fix broken chart icon URL — upstream Keycloak moved keycloak_icon_512px.svg to icon.svg (#64)

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.6.0"
+          value: "quay.io/keycloak/keycloak:26.6.1"
 
   - it: should use custom image tag when set
     set:
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "my-registry/keycloak:26.6.0"
+          value: "my-registry/keycloak:26.6.1"
 
   - it: should set replica count
     set:
@@ -262,7 +262,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "quay.io/keycloak/keycloak:26.6.0"
+          value: "quay.io/keycloak/keycloak:26.6.1"
 
   - it: should set hardened securityContext on build init container
     set:

--- a/charts/keycloak/tests/serviceaccount_test.yaml
+++ b/charts/keycloak/tests/serviceaccount_test.yaml
@@ -52,6 +52,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: keycloak-26.6.0
+            helm.sh/chart: keycloak-26.6.1
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "26.6.0"
+            app.kubernetes.io/version: "26.6.1"


### PR DESCRIPTION
## Summary

- Bump Keycloak `appVersion` and chart `version` from 26.6.0 to 26.6.1
- Upstream security and bugfix release:
  - CVE-2026-4366: Blind Server-Side Request Forgery (SSRF) via HTTP redirect handling
  - CVE-2026-4633: User enumeration via identity-first login
  - Multiple additional bugfixes — see [upstream release notes](https://github.com/keycloak/keycloak/releases/tag/26.6.1)
- Updated test assertions (`deployment_test.yaml`, `serviceaccount_test.yaml`), `CHANGELOG.md`, and `artifacthub.io/changes`

Closes #72

## How to verify

```bash
make test
make e2e-keycloak
make e2e-oidc-keycloak
```

Locally verified: 102/102 unit tests pass; all three keycloak e2e scenarios (dev, postgres, replicas) pass; netbird ↔ keycloak 26.6.1 OIDC flow passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)