### PR TITLE
chore: prepare netbird v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## [0.4.2] — 2026-04-21
+
 ### Added
 
 - **netbird**: Fail-fast Helm template validation that rejects
@@ -17,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **netbird**: Bump appVersion from 0.68.2 to 0.68.3.
+  See [v0.68.3 release notes](https://github.com/netbirdio/netbird/releases/tag/v0.68.3) (#71).
 - **netbird**: README and `values.yaml` examples now show
   `exposedAddress` with an explicit `:443` port and document that the
   port is required even when it matches the scheme default.

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netbird
 description: A Helm chart for deploying NetBird VPN management, signal, dashboard, and relay services on Kubernetes
 type: application
-version: 0.4.1
-appVersion: "0.68.2"
+version: 0.4.2
+appVersion: "0.68.3"
 keywords:
   - netbird
   - vpn
@@ -31,6 +31,6 @@ annotations:
       url: https://github.com/KitStream/initium
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump NetBird from 0.68.1 to 0.68.2
-    - kind: changed
-      description: Document STUN networking setup in README
+      description: Bump NetBird from 0.68.2 to 0.68.3
+    - kind: added
+      description: Fail-fast validation rejecting exposedAddress without an explicit port

--- a/charts/netbird/tests/server-deployment_test.yaml
+++ b/charts/netbird/tests/server-deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "netbirdio/netbird-server:0.68.2"
+          value: "netbirdio/netbird-server:0.68.3"
 
   - it: should use custom image tag when set
     set:

--- a/charts/netbird/tests/serviceaccount_test.yaml
+++ b/charts/netbird/tests/serviceaccount_test.yaml
@@ -62,6 +62,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: netbird-0.4.1
+            helm.sh/chart: netbird-0.4.2
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/version: "0.68.2"
+            app.kubernetes.io/version: "0.68.3"


### PR DESCRIPTION
## Summary

- Bump chart version `0.4.1` → `0.4.2`
- Bump appVersion `0.68.2` → `0.68.3` (#71)

Upstream release notes: [v0.68.3](https://github.com/netbirdio/netbird/releases/tag/v0.68.3) — management context-cancel monitoring and a CI proto-version check (backend-only changes).

Closes #71.

## Test plan

- [x] `make test` — lint + 295 unit tests pass
- [x] `make e2e-netbird` — sqlite, postgres, mysql, and OIDC (keycloak + zitadel) scenarios pass with 0.68.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)