### PR TITLE
chore: prepare keycloak v26.6.3 release

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: A Helm chart for deploying Keycloak IAM using the upstream quay.io/keycloak/keycloak image on Kubernetes
 type: application
-version: 26.6.1
+version: 26.6.3
 appVersion: "26.6.3"
 keywords:
   - keycloak
@@ -30,9 +30,7 @@ annotations:
     - name: Source
       url: https://github.com/KitStream/helms
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump Keycloak from 26.6.0 to 26.6.1 (security and bugfix release)
     - kind: security
-      description: "Upstream security fixes: CVE-2026-4366 (SSRF via HTTP redirect), CVE-2026-4633 (user enumeration via identity-first login)"
+      description: Bump Keycloak from 26.6.1 to 26.6.3 — ~32 upstream CVE fixes including session fixation, redirect-URI bypass, SSRF, and refresh-token reuse
     - kind: fixed
-      description: Fix broken chart icon URL — upstream Keycloak moved keycloak_icon_512px.svg to icon.svg (#64)
+      description: Publish not-ready addresses on the JGroups headless service so simultaneously started replicas form a single cluster instead of split-brain merging late

--- a/charts/keycloak/tests/serviceaccount_test.yaml
+++ b/charts/keycloak/tests/serviceaccount_test.yaml
@@ -52,6 +52,6 @@ tests:
       - isSubset:
           path: metadata.labels
           content:
-            helm.sh/chart: keycloak-26.6.1
+            helm.sh/chart: keycloak-26.6.3
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/version: "26.6.3"


### PR DESCRIPTION
## Summary

Release **keycloak 26.6.3** — chart version syncs with the upstream Keycloak appVersion (already 26.6.3 on main via #100). Changes since the `keycloak-26.6.1` tag:

- **Security**: Keycloak 26.6.1 → 26.6.3 (~32 upstream CVE fixes incl. session fixation, redirect-URI bypass, SSRF, refresh-token reuse); also fixes a post-realm-migration exit-code-1 bug
- **Fixed**: `publishNotReadyAddresses: true` on the JGroups headless service — simultaneously started replicas previously formed singleton clusters and merged late (split-brain), losing cache invalidations (manifested as 403s in the replicas e2e)

Merging this triggers the release workflow (GHCR OCI push, `keycloak-26.6.3` tag, GitHub release).

## How to verify

```sh
helm lint charts/keycloak    # clean
helm unittest charts/keycloak  # 103 tests passing
make e2e-keycloak            # all 3 scenarios passed on this content in PR #100 CI
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)