### PR TITLE
implement fix for #104

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -31,12 +31,10 @@ annotations:
       url: https://github.com/KitStream/initium
   artifacthub.io/changes: |
     - kind: added
-      description: Gateway API support (HTTPRoute, GRPCRoute, TCPRoute) as an alternative to Ingress, with fail-fast validation rejecting ingressGrpc without TLS
+      description: Add dedicated server-grpc Service with appProtocol kubernetes.io/h2c for Envoy-based Gateway API controllers (Cilium, Envoy Gateway)
     - kind: added
-      description: External relay configuration via server.config.relays with dedicated relay credential secret
-    - kind: added
-      description: server.stunService.nodePort value for a fixed STUN NodePort
+      description: Add dedicated server-relay Service with appProtocol kubernetes.io/ws for Envoy-based Gateway API controllers (Cilium, Envoy Gateway)
     - kind: changed
-      description: Bump NetBird from 0.68.3 to 0.72.3
+      description: GRPCRoute default backendRef now points to the server-grpc Service when backendRefs is not specified
     - kind: changed
-      description: Bump dashboard image from v2.32.4 to v2.39.0
+      description: Relay HTTPRoute default backendRef now points to the server-relay Service when backendRefs is not specified

--- a/charts/netbird/templates/server-grpc-service.yaml
+++ b/charts/netbird/templates/server-grpc-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netbird.server.fullname" . }}-grpc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "netbird.server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - appProtocol: kubernetes.io/h2c
+      name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "netbird.server.selectorLabels" . | nindent 4 }}

--- a/charts/netbird/templates/server-grpcroute.yaml
+++ b/charts/netbird/templates/server-grpcroute.yaml
@@ -4,7 +4,7 @@
 {{- range .Values.server.grpcRoute.rules }}
   {{- $rule := deepCopy . }}
   {{- if not (hasKey $rule "backendRefs") }}
-    {{- $_ := set $rule "backendRefs" (list (dict "name" $serviceName "port" 80)) }}
+    {{- $_ := set $rule "backendRefs" (list (dict "name" (printf "%s-grpc" $serviceName) "port" 80)) }}
   {{- end }}
   {{- $rules = append $rules $rule }}
 {{- end }}

--- a/charts/netbird/templates/server-relay-httproute.yaml
+++ b/charts/netbird/templates/server-relay-httproute.yaml
@@ -4,7 +4,7 @@
 {{- range .Values.server.relayHttpRoute.rules }}
   {{- $rule := deepCopy . }}
   {{- if not (hasKey $rule "backendRefs") }}
-    {{- $_ := set $rule "backendRefs" (list (dict "name" $serviceName "port" 80)) }}
+    {{- $_ := set $rule "backendRefs" (list (dict "name" (printf "%s-relay" $serviceName) "port" 80)) }}
   {{- end }}
   {{- $rules = append $rules $rule }}
 {{- end }}

--- a/charts/netbird/templates/server-relay-service.yaml
+++ b/charts/netbird/templates/server-relay-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netbird.server.fullname" . }}-relay
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "netbird.server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - appProtocol: kubernetes.io/ws
+      name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "netbird.server.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Implements two new Services:

- `server-relay-service.yaml`: same selector as the main Service, `appProtocol: kubernetes.io/ws`
- `server-grpc-service.yaml`: same selector as the main Service, `appProtocol: kubernetes.io/h2c`

Updates the templates `server-relay-httproute.yaml` and `server-grpcroute.yaml` to default to the appropriate Service when no backendRefs are specified in the values.yaml.

- closes #104 